### PR TITLE
feat: add projects page

### DIFF
--- a/pages/projects.md
+++ b/pages/projects.md
@@ -1,0 +1,6 @@
+---
+title: Projects
+description: younggglcy's projects
+---
+
+<ListProjects />

--- a/src/assets/icons/markdown-it-shiki-extra.svg
+++ b/src/assets/icons/markdown-it-shiki-extra.svg
@@ -1,0 +1,38 @@
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background gradient -->
+  <defs>
+    <linearGradient id="bgGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#667eea;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#764ba2;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient id="accentGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#f093fb;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#f5576c;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  
+  <!-- Main rounded rectangle background -->
+  <rect width="128" height="128" rx="24" fill="url(#bgGradient)"/>
+  
+  <!-- Markdown "M" symbol with down arrow integrated -->
+  <path d="M 24 38 L 24 90 L 34 90 L 34 54 L 46 68 L 58 54 L 58 90 L 68 90 L 68 38 L 58 38 L 46 52 L 34 38 Z" 
+        fill="white" opacity="0.95"/>
+  
+  <!-- Code brackets with syntax highlighting dots -->
+  <path d="M 76 50 L 66 64 L 76 78" 
+        stroke="url(#accentGradient)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <path d="M 96 50 L 106 64 L 96 78" 
+        stroke="url(#accentGradient)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  
+  <!-- Syntax highlighting dots (representing colored code) -->
+  <circle cx="82" cy="58" r="2.5" fill="#4ade80"/>
+  <circle cx="90" cy="58" r="2.5" fill="#60a5fa"/>
+  <circle cx="82" cy="64" r="2.5" fill="#f87171"/>
+  <circle cx="90" cy="64" r="2.5" fill="#fbbf24"/>
+  <circle cx="82" cy="70" r="2.5" fill="#a78bfa"/>
+  <circle cx="90" cy="70" r="2.5" fill="#34d399"/>
+  
+  <!-- Sparkle/Extra indicator (top right corner) -->
+  <path d="M 108 24 L 110 30 L 116 32 L 110 34 L 108 40 L 106 34 L 100 32 L 106 30 Z" 
+        fill="#fbbf24" opacity="0.9"/>
+</svg>

--- a/src/components/ListProjects.vue
+++ b/src/components/ListProjects.vue
@@ -1,0 +1,157 @@
+<script setup lang="ts">
+import MarkdownItShikiExtraIcon from '~icons/local/markdown-it-shiki-extra?raw'
+import { vMarkdownIt } from '~/directives'
+
+interface Project {
+  name: string
+  description: string
+  link: string
+  archived?: boolean
+  icon: string
+}
+
+let projects: Project[] = [
+  {
+    name: 'Markdown-it-shiki-extra',
+    description: '[Markdown It](https://markdown-it.github.io/) plugin for [Shiki](https://github.com/shikijs/shiki) with extra options.',
+    icon: MarkdownItShikiExtraIcon,
+    archived: true,
+    link: 'https://github.com/younggglcy/markdown-it-shiki-extra',
+  },
+  {
+    name: 'Simple Reminder',
+    description: 'A simple reminder for vscode',
+    icon: 'https://raw.githubusercontent.com/GODLiangCY/reminder/main/reminder.png',
+    archived: true,
+    link: 'https://github.com/younggglcy/reminder',
+  },
+]
+
+projects = projects.toSorted((a, b) => {
+  if (a.archived && !b.archived)
+    return 1
+  if (!a.archived && b.archived)
+    return -1
+  return 0
+})
+
+function handleClick(link: string, event: MouseEvent) {
+  // 如果点击的是链接，不执行卡片的点击事件
+  const target = event.target as HTMLElement
+  if (target.tagName === 'A' || target.closest('a')) {
+    return
+  }
+  window.open(link, '_blank')
+}
+
+const iconClass = 'icon-container w-14 h-14 flex-shrink-0 rounded-lg bg-gradient-to-br from-blue-50 to-purple-50 dark:from-blue-900/20 dark:to-purple-900/20 p-2 group-hover:scale-110 transition-transform duration-300'
+</script>
+
+<template>
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+    <div
+      v-for="project in projects"
+      :key="project.name"
+      class="project-card group p-5 rounded-xl border-2 border-gray-200 dark:border-gray-700 hover:border-blue-400 dark:hover:border-blue-500 transition-all duration-300 hover:shadow-lg cursor-pointer bg-white dark:bg-gray-800/30"
+      @click="handleClick(project.link, $event)"
+    >
+      <div class="flex items-center gap-4">
+        <div v-if="project.icon.startsWith('http')" :class="iconClass">
+          <img :src="project.icon" alt="" class="w-full h-full object-contain">
+        </div>
+        <div v-else :class="iconClass" v-html="project.icon" />
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center gap-2 mb-1">
+            <h3 class="text-lg font-bold m-0 leading-tight group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
+              {{ project.name }}
+            </h3>
+            <span v-if="project.archived" class="text-xs px-2 py-0.5 rounded-full bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-400 border border-yellow-200 dark:border-yellow-800">
+              Archived
+            </span>
+          </div>
+          <div
+            v-markdown-it="project.description"
+            class="prose project-description"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.icon-container {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.icon-container :deep(svg) {
+  width: 100%;
+  height: 100%;
+  display: block;
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.1));
+}
+
+.project-card {
+  position: relative;
+  overflow: hidden;
+}
+
+.project-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, #3b82f6, #8b5cf6);
+  transform: scaleX(0);
+  transition: transform 0.3s ease;
+}
+
+.project-card:hover::before {
+  transform: scaleX(1);
+}
+
+.project-card:hover {
+  transform: translateY(-4px);
+}
+
+.project-description {
+  opacity: 0.75;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  margin-top: 0.25rem;
+}
+
+.project-description :deep(p) {
+  margin: 0;
+  line-height: 1.5;
+}
+
+.project-description :deep(a) {
+  text-decoration: none;
+  color: #3b82f6;
+  font-weight: 500;
+  position: relative;
+  transition: color 0.2s ease;
+}
+
+.dark .project-description :deep(a) {
+  color: #60a5fa;
+}
+
+.project-description :deep(a:hover) {
+  color: #2563eb;
+  text-decoration: underline;
+}
+
+.dark .project-description :deep(a:hover) {
+  color: #93c5fd;
+}
+
+h3 {
+  line-height: 1.3;
+}
+</style>

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -22,7 +22,7 @@ import ToggleTheme from './ToggleTheme.vue'
         </router-link>
         <router-link to="/projects" title="Projects">
           <span class="lt-sm:hidden darker">Projects</span>
-          <div ix:projects sm:hidden />
+          <div i-ix:projects sm:hidden />
         </router-link>
         <router-link to="/friends" title="friends' link" class="lt-sm:hidden">
           <span class="lt-sm:hidden darker">Friends</span>
@@ -30,7 +30,7 @@ import ToggleTheme from './ToggleTheme.vue'
         </router-link>
         <router-link to="/use" title="Use">
           <span class="lt-sm:hidden darker">Use</span>
-          <div clarity:tools-solid sm:hidden />
+          <div i-clarity:tools-solid sm:hidden />
         </router-link>
         <a href="https://github.com/younggglcy" target="_blank" title="GitHub">
           <div i-uil-github-alt />

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -20,6 +20,10 @@ import ToggleTheme from './ToggleTheme.vue'
           <span class="lt-sm:hidden darker">Blog</span>
           <div i-ri-article-line sm:hidden />
         </router-link>
+        <router-link to="/projects" title="Projects">
+          <span class="lt-sm:hidden darker">Projects</span>
+          <div ix:projects sm:hidden />
+        </router-link>
         <router-link to="/friends" title="friends' link" class="lt-sm:hidden">
           <span class="lt-sm:hidden darker">Friends</span>
           <div i-fa-solid:user-friends sm:hidden />

--- a/src/components/PostItem.vue
+++ b/src/components/PostItem.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import MarkdownIt from 'markdown-it'
+import { vMarkdownIt } from '~/directives'
 
 const props = defineProps<{
   date: string
@@ -14,9 +14,6 @@ const props = defineProps<{
 defineEmits<{
   (e: 'tagClick', name: string): void
 }>()
-
-const md = new MarkdownIt()
-const desc = md.render(props.description)
 </script>
 
 <template>
@@ -32,7 +29,7 @@ const desc = md.render(props.description)
       <span flex items-center><i-bi:book mr-3 />{{ props.words }}</span>
       <span flex items-center><i-ep:timer mr-3 />{{ props.duration }}</span>
     </div>
-    <div class="prose mt-1" v-html="desc" />
+    <div v-markdown-it="props.description" class="prose mt-1" />
     <div flex items-center flex-wrap>
       <div v-for="tag of props.tags" :key="tag" flex items-center mt-4 class="basis-1/4">
         <i-carbon:tag-group hover:cursor-pointer @click="$emit('tagClick', tag)" />

--- a/src/directives/index.ts
+++ b/src/directives/index.ts
@@ -1,1 +1,2 @@
 export { vInfiniteScroll } from './infinite-scroll'
+export { vMarkdownIt } from './markdown-it'

--- a/src/directives/markdown-it.ts
+++ b/src/directives/markdown-it.ts
@@ -3,6 +3,20 @@ import MarkdownIt from 'markdown-it'
 
 const md = new MarkdownIt()
 
+// Copied from https://github.com/markdown-it/markdown-it/blob/master/docs/architecture.md#renderer
+// Remember the old renderer if overridden, or proxy to the default renderer.
+const defaultRender = md.renderer.rules.link_open || function (tokens, idx, options, env, self) {
+  return self.renderToken(tokens, idx, options)
+}
+
+md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
+  // Add a new `target` attribute, or replace the value of the existing one.
+  tokens[idx].attrSet('target', '_blank')
+
+  // Pass the token to the default renderer.
+  return defaultRender(tokens, idx, options, env, self)
+}
+
 export const vMarkdownIt: Directive<HTMLElement, string> = {
   mounted(el, binding) {
     if (binding.value) {

--- a/src/directives/markdown-it.ts
+++ b/src/directives/markdown-it.ts
@@ -1,0 +1,17 @@
+import type { Directive } from 'vue'
+import MarkdownIt from 'markdown-it'
+
+const md = new MarkdownIt()
+
+export const vMarkdownIt: Directive<HTMLElement, string> = {
+  mounted(el, binding) {
+    if (binding.value) {
+      el.innerHTML = md.render(binding.value)
+    }
+  },
+  updated(el, binding) {
+    if (binding.value) {
+      el.innerHTML = md.render(binding.value)
+    }
+  },
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,7 @@ import Anchor from 'markdown-it-anchor'
 import LinkAttributes from 'markdown-it-link-attributes'
 import TOC from 'markdown-it-table-of-contents'
 import Unocss from 'unocss/vite'
+import { FileSystemIconLoader } from 'unplugin-icons/loaders'
 import IconsResolver from 'unplugin-icons/resolver'
 import Icons from 'unplugin-icons/vite'
 import Components from 'unplugin-vue-components/vite'
@@ -64,7 +65,12 @@ export default defineConfig({
       ],
     }),
 
-    Icons(),
+    Icons({
+      compiler: 'vue3',
+      customCollections: {
+        local: FileSystemIconLoader('./src/assets/icons'),
+      },
+    }),
 
     Unocss(),
 


### PR DESCRIPTION
This pull request introduces a new "Projects" page to the site, displaying a list of projects with improved markdown rendering and UI enhancements. It also refactors markdown rendering in post summaries to use a custom Vue directive, ensuring that all links open in a new tab. Additionally, it updates the navigation bar to include the new "Projects" page and enhances icon handling in the build setup.

**New Projects Page and Project List UI:**

- Added a new page at `/projects` that displays a list of projects using the new `ListProjects` Vue component, with support for project icons, archived status, and markdown-formatted descriptions. (`pages/projects.md`, `src/components/ListProjects.vue`) [[1]](diffhunk://#diff-ef9f169dc5d9b0bae29b15d93ea13bf14a19b710d47df77e1d8828446f67a187R1-R6) [[2]](diffhunk://#diff-a17389b422525807e3d9f02181ae07308f35cec9142f64a524682e6292d56651R1-R157)
- Updated the navigation bar (`NavBar.vue`) to include a link to the new "Projects" page.

**Markdown Rendering Improvements:**

- Introduced a custom Vue directive `vMarkdownIt` for rendering markdown, ensuring all links open in a new tab by default. (`src/directives/markdown-it.ts`, `src/directives/index.ts`) [[1]](diffhunk://#diff-60a0200ba2607e6a8795c4830b4f6abaddf3729e5129feaaf1c31ef520a53c72R1-R31) [[2]](diffhunk://#diff-63f55f95008493273f799c6300cf93e525b08d1ce7f67bf846c1f2ce2db76339R2)
- Refactored `PostItem.vue` to use the new `vMarkdownIt` directive for rendering post descriptions, replacing the previous direct use of `markdown-it`. [[1]](diffhunk://#diff-cf937a3e3fc90245d6cb5832b048450addb72d67dd386e08eaef62c2f672d0a3L2-R2) [[2]](diffhunk://#diff-cf937a3e3fc90245d6cb5832b048450addb72d67dd386e08eaef62c2f672d0a3L17-L19) [[3]](diffhunk://#diff-cf937a3e3fc90245d6cb5832b048450addb72d67dd386e08eaef62c2f672d0a3L35-R32)

**Icon Handling Enhancements:**

- Configured the Vite build to support custom local icon collections using `unplugin-icons`, enabling SVG icons to be loaded from the filesystem for use in components like `ListProjects`. (`vite.config.ts`) [[1]](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddR14) [[2]](diffhunk://#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890ddL67-R73)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a Projects page with a responsive grid of project cards, including icons, descriptions, and an Archived badge.
  - Added a “Projects” navigation link; project cards open the project in a new tab while inline links remain clickable.

- Enhancements
  - Markdown rendering now uses a reusable directive; links in rendered Markdown open in new tabs.

- Chores
  - Enabled a local icon collection to support custom icons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->